### PR TITLE
Add support for multiple and all deletions to Delete command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -2,16 +2,19 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
 /**
- * Deletes a person identified using it's displayed index from the address book.
+ * Deletes multiple/all persons in the address book, or a person identified using it's
+ * displayed index from the address book.
  */
 public class DeleteCommand extends Command {
 
@@ -23,31 +26,93 @@ public class DeleteCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String MESSAGE_DELETE_ALL_PERSONS_SUCCESS = "Deleted all persons in address book";
+    public static final String MESSAGE_DELETE_ALL_SHOWN_PERSONS_SUCCESS = "Deleted %d Persons:";
+
+    private enum Quantity { ONE, ALL, SHOWN }
 
     private final Index targetIndex;
 
+    private final Quantity quantity;
+
     public DeleteCommand(Index targetIndex) {
+        this(targetIndex, Quantity.ONE);
+    }
+
+    private DeleteCommand(Index targetIndex, Quantity quantity) {
         this.targetIndex = targetIndex;
+        this.quantity = quantity;
+    }
+
+    public static DeleteCommand all() {
+        return new DeleteCommand(null, Quantity.ALL);
+    }
+
+    public static DeleteCommand allShown() {
+        return new DeleteCommand(null, Quantity.SHOWN);
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        switch (this.quantity) {
+        case ONE: return deletePerson(model);
+        case ALL: return deleteAll(model);
+        default:
+        case SHOWN: return deleteAllShown(model);
+        }
+    }
+
+    private CommandResult deletePerson(Model model) throws CommandException {
         List<Person> lastShownList = model.getFilteredPersonList();
 
+        requireNonNull(targetIndex);
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
+
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
+    }
+
+    private CommandResult deleteAll(Model model) {
+        model.setAddressBook(new AddressBook());
+        return new CommandResult(MESSAGE_DELETE_ALL_PERSONS_SUCCESS);
+    }
+
+    private CommandResult deleteAllShown(Model model) {
+        List<Person> personsToDelete = new ArrayList<>(model.getFilteredPersonList());
+
+        for (Person person : personsToDelete) {
+            model.deletePerson(person);
+        }
+
+        StringBuilder resultSb = new StringBuilder(MESSAGE_DELETE_ALL_SHOWN_PERSONS_SUCCESS);
+        for (Person person : personsToDelete) {
+            resultSb.append("\n");
+            resultSb.append(person);
+        }
+
+        return new CommandResult(String.format(resultSb.toString(), personsToDelete.size()));
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof DeleteCommand // instanceof handles nulls
-                && targetIndex.equals(((DeleteCommand) other).targetIndex)); // state check
+                && this.equals((DeleteCommand) other)); // state check
+    }
+
+    private boolean equals(DeleteCommand other) {
+        if (this.quantity != other.quantity) {
+            return false;
+        } else if (this.quantity == Quantity.ONE) {
+            return this.targetIndex.equals(other.targetIndex);
+        } else {
+            return true;
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -2,6 +2,9 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.Arrays;
+import java.util.List;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -17,6 +20,16 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
+        System.out.println(args);
+        List<String> argList = Arrays.asList(args.trim().split("\\s+"));
+
+        if (argList.size() == 1 && argList.get(0).equals("-a")) {
+            return DeleteCommand.all();
+        } else if (argList.size() == 2
+                && argList.contains("-a")
+                && argList.contains("-f")) {
+            return DeleteCommand.allShown();
+        }
         try {
             Index index = ParserUtil.parseIndex(args);
             return new DeleteCommand(index);


### PR DESCRIPTION
Add options to the `delete` command to delete multiple persons:
- `delete -a` clears all persons in the address book
- `delete -a -f` removes all persons shown in the window