### PR TITLE
Modify delete command syntax and add tests for DeleteCommandParser

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -23,8 +23,8 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by the index number used, "
             + "or all persons, in the displayed person list.\n"
-            + "Parameters: INDEX (must be a positive integer) / -a (-f)\n"
-            + "Examples: " + COMMAND_WORD + " 1, " + COMMAND_WORD + " -a -f";
+            + "Parameters: INDEX (must be a positive integer) / -a / -f\n"
+            + "Examples: " + COMMAND_WORD + " 1, " + COMMAND_WORD + " -f";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
     public static final String MESSAGE_DELETE_ALL_PERSONS_SUCCESS = "Deleted all persons in address book";

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -25,6 +25,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
 
         if (argList.size() == 1 && argList.get(0).equals("-a")) {
             return DeleteCommand.all();
+        } else if (argList.size() == 1 && argList.get(0).equals("-f")) {
+            return DeleteCommand.allShown();
         } else if (argList.size() == 2
                 && argList.contains("-a")
                 && argList.contains("-f")) {

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -26,6 +26,22 @@ public class DeleteCommandParserTest {
     }
 
     @Test
+    public void parse_all_returnsDeleteCommandAll() {
+        assertParseSuccess(parser, "-a", DeleteCommand.all());
+    }
+
+    @Test
+    public void parse_found_returnsDeleteCommandAllShown() {
+        assertParseSuccess(parser, "-f", DeleteCommand.allShown());
+    }
+
+    @Test
+    public void parse_allAndFound_returnsDeleteCommandAllShown() {
+        assertParseSuccess(parser, "-a -f", DeleteCommand.allShown());
+        assertParseSuccess(parser, "-f -a", DeleteCommand.allShown());
+    }
+
+    @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }


### PR DESCRIPTION
1. Modify `delete` command to allow `delete -f` to perform the same delete action as `delete -a -f`/`delete -f -a`
2. Add tests in `DeleteCommandParserTest` to achieve 100% line code coverage in `DeleteCommandParser`