### PR TITLE
Fix delete and edit commands requiring multiple undos to reverse

### DIFF
--- a/src/main/java/seedu/address/logic/commands/BulkTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BulkTagCommand.java
@@ -57,7 +57,7 @@ public class BulkTagCommand extends Command {
             Person taggedPerson = new Person(person.getName(), person.getPhone(), person.getEmail(),
                     person.getAddress(), newTagList, person.getGitHubId(),
                     person.getNusNetworkId(), person.getType(), person.getStudentId(), person.getTutorialId());
-            model.setPerson(person, taggedPerson);
+            model.setPerson(person, taggedPerson, false);
         }
 
         return getCommandResult(tagList, personsToTag);

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -86,9 +86,7 @@ public class DeleteCommand extends Command {
     private CommandResult deleteAllShown(Model model) {
         List<Person> personsToDelete = new ArrayList<>(model.getFilteredPersonList());
 
-        for (Person person : personsToDelete) {
-            model.deletePerson(person);
-        }
+        model.deletePersons(personsToDelete);
 
         StringBuilder resultSb = new StringBuilder(MESSAGE_DELETE_ALL_SHOWN_PERSONS_SUCCESS);
         for (Person person : personsToDelete) {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -11,7 +11,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENT_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIAL_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TYPE;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -96,8 +95,7 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
-        model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.setPerson(personToEdit, editedPerson, true);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
@@ -76,6 +77,12 @@ public interface Model {
      * The person must exist in the address book.
      */
     void deletePerson(Person target);
+
+    /**
+     * Deletes all persons in a list.
+     * The persons must exist in the address book.
+     */
+    void deletePersons(List<Person> targets);
 
     /**
      * Adds the given person.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -95,7 +95,7 @@ public interface Model {
      * {@code target} must exist in the address book.
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
      */
-    void setPerson(Person target, Person editedPerson);
+    void setPerson(Person target, Person editedPerson, boolean removeFilter);
 
     void importFile(Path filePath) throws DataConversionException;
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -121,6 +122,11 @@ public class ModelManager implements Model {
     @Override
     public void deletePerson(Person target) {
         runOperation(() -> addressBook.removePerson(target));
+    }
+
+    @Override
+    public void deletePersons(List<Person> targets) {
+        runOperation(() -> targets.forEach(addressBook::removePerson));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -138,9 +138,14 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void setPerson(Person target, Person editedPerson) {
+    public void setPerson(Person target, Person editedPerson, boolean removeFilter) {
         requireAllNonNull(target, editedPerson);
-        runOperation(() -> addressBook.setPerson(target, editedPerson));
+        runOperation(() -> {
+            addressBook.setPerson(target, editedPerson);
+            if (removeFilter) {
+                this.filteredPersons.setPredicate(PREDICATE_SHOW_ALL_PERSONS);
+            }
+        });
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -157,7 +157,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void setPerson(Person target, Person editedPerson) {
+        public void setPerson(Person target, Person editedPerson, boolean removeFilter) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -147,6 +148,11 @@ public class AddCommandTest {
 
         @Override
         public void deletePerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deletePersons(List<Person> targets) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -43,7 +43,7 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson, false);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -64,7 +64,7 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(lastPerson, editedPerson);
+        expectedModel.setPerson(lastPerson, editedPerson, false);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -93,7 +93,7 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson, false);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }


### PR DESCRIPTION
Fixes #147, #167 and #171.

Modifies all commands to only call `Model` write methods once per operation.