### PR TITLE
Allow full and partial matching for tags

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -132,6 +132,7 @@ Format: `find {n/|s/|N/|g/|T/|r/|p/|a/|t/} KEYWORD [MORE_KEYWORDS]`
 * The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`.
 * All attributes can be searched, by specifying the prefix before the keyword.
 * Partial matching can be done for all attributes except Tutorial ID and Role e.g. for name, Han will match Hans.
+* Partial matching is performed from the first letter of each value, i.e. `find n/o` will return Charlotte Oliveiro since Oliveiro starts with 'o', but will not return Alex Yeoh or Roy Balakrishnan since they do not contain values starting with the specified key.
 * Persons matching at least one keyword will be returned (i.e. `OR` search).
   e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -126,15 +126,16 @@ Examples:
 
 Finds persons with the given search criteria and value.
 
-Format: `find {n/|s/|N/|g/|T/|r/|p/|a/|t/} KEYWORD [MORE_KEYWORDS]`
+Format: `find {n/|s/|N/|g/|T/|r/|p/|a/|t/full/|t/partial/}KEYWORD [MORE_KEYWORDS]`
 
 * The search is case-insensitive. e.g friend will also match Friend or FrIend or FRIEND.
 * The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`.
 * All attributes can be searched, by specifying the prefix before the keyword.
 * Partial matching can be done for all attributes except Tutorial ID and Role e.g. for name, Han will match Hans.
 * Partial matching is performed from the first letter of each value, i.e. `find n/o` will return Charlotte Oliveiro since Oliveiro starts with 'o', but will not return Alex Yeoh or Roy Balakrishnan since they do not contain values starting with the specified key.
+* Tags can be searched either using full or partial matching, using `t/full/` for full keyword matching and `t/` for partial matching. The first key to be searched should appear right after the prefix, e.g. `find t/full/friends`.
 * Persons matching at least one keyword will be returned (i.e. `OR` search).
-  e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
+ e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
 
 Examples:
 * `find n/Hans Bo` will return `Hans Gruber`, and `Bo Yang`

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -16,9 +16,17 @@ import seedu.address.model.person.TutorialIdOrRoleContainsKeywordsPredicate;
  */
 public class FindCommandParser implements Parser<FindCommand> {
 
+    public static final String NAME_TYPE = "n/";
+    public static final String STUDENT_ID_TYPE = "s/";
+    public static final String NUSNET_ID_TYPE = "N/";
+    public static final String EMAIL_TYPE = "e/";
+    public static final String GITHUB_ID_TYPE = "g/";
+    public static final String PHONE_TYPE = "p/";
+    public static final String ADDRESS_TYPE = "a/";
     public static final String TUTORIAL_ID_TYPE = "T/";
     public static final String ROLE_TYPE = "r/";
     public static final String TAG_TYPE = "t/";
+    public static final String TAG_TYPE_FULL = "t/full";
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
@@ -27,13 +35,30 @@ public class FindCommandParser implements Parser<FindCommand> {
      */
     public FindCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
+        boolean containsTypeCommand = trimmedArgs.contains(NAME_TYPE)
+                || trimmedArgs.contains(STUDENT_ID_TYPE)
+                || trimmedArgs.contains(NUSNET_ID_TYPE)
+                || trimmedArgs.contains(EMAIL_TYPE)
+                || trimmedArgs.contains(GITHUB_ID_TYPE)
+                || trimmedArgs.contains(PHONE_TYPE)
+                || trimmedArgs.contains(ADDRESS_TYPE)
+                || trimmedArgs.contains(TUTORIAL_ID_TYPE)
+                || trimmedArgs.contains(ROLE_TYPE)
+                || trimmedArgs.contains(TAG_TYPE)
+                || trimmedArgs.contains(TAG_TYPE_FULL);
+
+        String[] typeKeywords = trimmedArgs.split("\\s+");
         // if the length of trimmedArgs is 2, only the command e.g. 'n/' has been provided, with no keys to search
-        if (trimmedArgs.length() == 2 || !trimmedArgs.contains("/")) {
+        if (trimmedArgs.length() <= 2 || !trimmedArgs.contains("/") || !containsTypeCommand
+                || trimmedArgs.equals("t/full/") || typeKeywords[0].length() == 2
+                || (typeKeywords[0].length() == 7 && typeKeywords[0].contains("t/full/"))) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] typeKeywords = trimmedArgs.split("\\s+");
+        //check that there is a key inputted for the command after the attribute type
+        assert(typeKeywords[0].length() > 2);
+
         //check that the attribute type is inputted as a 2-character string, e.g. "n/" and not "n/alex"
         //assert(typeKeywords[0].length() == 2);
         String type = typeKeywords[0].substring(0, 2);

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -28,14 +28,12 @@ public class FindCommandParser implements Parser<FindCommand> {
     public FindCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
         // if the length of trimmedArgs is 2, only the command e.g. 'n/' has been provided, with no keys to search
-        if (trimmedArgs.length() == 2) {
+        if (trimmedArgs.length() == 2 || !trimmedArgs.contains("/")) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
         String[] typeKeywords = trimmedArgs.split("\\s+");
-        //check that there is a key inputted for the command after the attribute type
-        assert(typeKeywords[0].length() > 2);
         //check that the attribute type is inputted as a 2-character string, e.g. "n/" and not "n/alex"
         //assert(typeKeywords[0].length() == 2);
         String type = typeKeywords[0].substring(0, 2);

--- a/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
@@ -1,5 +1,6 @@
 package seedu.address.model.person;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -30,15 +31,29 @@ public class TagContainsKeywordsPredicate extends AttributeContainsKeywordsPredi
      */
     public boolean test(Person person) {
         Set<Tag> tags = person.getTags();
+        List<String> keywordsCopy = new ArrayList<>(keywords);
         Iterator<Tag> values = tags.iterator();
-        String s = "";
-        while (values.hasNext()) {
-            String nextValue = values.next().toString();
-            s += allPrefixes(nextValue);
+        StringBuilder s = new StringBuilder();
+        String key = keywordsCopy.get(0);
+        if (key.contains("full/")) {
+            keywordsCopy.add(key.substring(5));
+            while (values.hasNext()) {
+                String nextValue = values.next().toString();
+                String nextTag = nextValue.substring(1, nextValue.length() - 1);
+                s.append(nextTag).append(" ");
+            }
+            final String str = s.toString();
+            return keywordsCopy.stream()
+                    .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(str, keyword));
+        } else {
+            while (values.hasNext()) {
+                String nextValue = values.next().toString();
+                s.append(allPrefixes(nextValue));
+            }
+            final String str = s.toString();
+            return keywords.stream()
+                    .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(str, keyword));
         }
-        final String str = s;
-        return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(str, keyword));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -26,10 +26,10 @@ public class FindCommandParserTest {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
                 new FindCommand(new PartialKeyContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"), NAMETYPE));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+        assertParseSuccess(parser, "n/Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser, " \n n/Alice \n \t Bob  \t", expectedFindCommand);
     }
 
 }


### PR DESCRIPTION
- Updated UG to reflect the command changes
- Users can now search for a tag either partially or fully. e.g. if there are 2 different tags 'CS2103' and 'CS2103T', the original implementation of find tags for partial matching would make it troublesome to find the persons with tag 'CS2103' since it would also return the persons with 'CS2103T' tag. 
- Users can now input `find t/full/CS2103` to search by full tags, and return the persons matching the searched key exactly.
- The original partial matching implementation still holds; `find t/CS2103` would return persons with tags matching both CS2103 and CS2103T.


Close #134 